### PR TITLE
Add local VTN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,7 +131,6 @@ dmypy.json
 .idea/
 
 *secret
-config_*.json
 .DS_Store
 AUTHORS
 ChangeLog

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - id: trailing-whitespace
   - id: check-merge-conflict
   - id: no-commit-to-branch  # blocks main commits.  To bypass do git commit --allow-empty
-  - id: pretty-format-json
+  # - id: pretty-format-json
 
 # For more information about mypy, see https://github.com/pre-commit/mirrors-mypy
 - repo: https://github.com/pre-commit/mirrors-mypy
@@ -27,8 +27,8 @@ repos:
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: v2.2.0
   hooks:
-  - id: pretty-format-toml
-    args: [--autofix]
+  # - id: pretty-format-toml
+  #   args: [--autofix]
   - id: pretty-format-yaml
     args: [--autofix]
     exclude: .copier-answer.yml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenADRVen Agent
 
 
-[![Passing?](https://github.com/VOLTTRON/volttron-openadr-ven/actions/workflows/run-tests.yml/badge.svg)](https://github.com/VOLTTRON/volttron-openadr-ven/actions/workflows/run-tests.yml)
+[![Passing?](https://github.com/eclipse-volttron/volttron-openadr-ven/actions/workflows/run-tests.yml/badge.svg)](https://github.com/eclipse-volttron/volttron-openadr-ven/actions/workflows/run-tests.yml?query=branch%3Adevelop)
 [![pypi version](https://img.shields.io/pypi/v/volttron-openadr-ven.svg)](https://pypi.org/project/volttron-openadr-ven/)
 
 
@@ -90,6 +90,67 @@ The required parameters for this agent are "ven_name" and "vtn_url". Below is an
 
 Save this configuration in a JSON file in your preferred location. An example of such a configuration is saved in the
 root of this repository; the file is named `config_example1.json`
+
+# Testing
+
+If you don't have a dedicated VTN to test the VolttronOpenADR against, you can setup a local VTN instead. After setting up a local VTN, configure an VolttronOpenADRVen Agent against that local VTN and then install the agent on your VOLTTRON instance.
+
+To setup a local VTN, we have provided a script and a custom agent configuration for convenience. Follow the steps below to setup a local VTN and corresponding Volttron OpenADRVen Agent:
+
+
+1. Create a virtual environment:
+
+
+    ```shell
+    python -m venv env
+    source env/bin/activate
+    ```
+
+
+1. Install [openleadr](https://pypi.org/project/openleadr/):
+
+    ```shell
+    pip install openleadr
+    ```
+
+1. At the top level of this project, run the VTN server in the foreground so that we can observe logs:
+
+    ```shell
+    python utils/vtn.py
+    ```
+
+1. Open up another terminal, create a folder called temp, and create another virtual environment:
+
+    ```shell
+    mkdir temp
+    cd temp
+    python -m venv env
+    source env/bin/activate
+    ```
+
+1. Install volttron:
+
+    ```shell
+    pip install volttron
+    ```
+
+1. Run volttron in the background:
+
+    ```shell
+    volttron -vv -l volttron.log &
+    ```
+
+1. Install the VolttronOpenADRVEN Agent using the configuration provided under `utils`:
+
+    ```shell
+    vctl install volttron-openadr-ven --agent-config utils/config_toy_ven.json --tag openadr --start
+    ```
+
+1. Observe the logs to verify that the Event from the local VTN was received by the VolttronOpenADRVEN agent
+
+    ```
+    tail -f volttron.log
+    ```
 
 
 # Development

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ root of this repository; the file is named `config_example1.json`
 
 # Testing
 
-If you don't have a dedicated VTN to test the VolttronOpenADR against, you can setup a local VTN instead. After setting up a local VTN, configure an VolttronOpenADRVen Agent against that local VTN and then install the agent on your VOLTTRON instance.
+If you don't have a dedicated VTN to test the VolttronOpenADR against, you can setup a local VTN instead. This VTN will be hosted at localhost on port 8080 (i.e. 127.0.0.1:8080). This VTN will accept registrations from a VEN named 'ven123', requests all reports that the VEN offers, and create an Event for the VEN. After setting up a local VTN, configure an VolttronOpenADRVen Agent against that local VTN and then install the agent on your VOLTTRON instance. Ensure that the VOLTTRON instance is running on the same host that the VTN is running on.
 
 To setup a local VTN, we have provided a script and a custom agent configuration for convenience. Follow the steps below to setup a local VTN and corresponding Volttron OpenADRVen Agent:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ python = ">=3.8,<4.0"
 volttron = "^10.0.2rc0"
 openleadr = "0.5.27"
 cryptography = ">=36.0.1,<37.0.0"
+gevent = "^21.12.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.2.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ python = ">=3.8,<4.0"
 volttron = "^10.0.2rc0"
 openleadr = "0.5.27"
 cryptography = ">=36.0.1,<37.0.0"
-gevent = "^21.12.0"
+
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.2.4"

--- a/utils/config_toy_ven.json
+++ b/utils/config_toy_ven.json
@@ -1,0 +1,5 @@
+{
+    "ven_name": "ven123",
+    "vtn_url": "http://127.0.0.1:8080/OpenADR2/Simple/2.0b",
+    "debug": true
+}

--- a/utils/vtn.py
+++ b/utils/vtn.py
@@ -1,0 +1,87 @@
+import asyncio
+from datetime import datetime, timezone, timedelta
+from openleadr import OpenADRServer, enable_default_logging
+from functools import partial
+
+enable_default_logging()
+
+
+async def on_create_party_registration(registration_info):
+    """
+    Inspect the registration info and return a ven_id and registration_id.
+    """
+    print(f"PARTY REGISTRTION")
+    if registration_info['ven_name'] == 'ven123':
+        ven_id = 'ven_id_123'
+        registration_id = 'reg_id_123'
+        return ven_id, registration_id
+    else:
+        return False
+
+
+async def on_register_report(ven_id, resource_id, measurement, unit, scale,
+                             min_sampling_interval, max_sampling_interval):
+    """
+    Inspect a report offering from the VEN and return a callback and sampling interval for receiving the reports.
+    """
+    callback = partial(on_update_report,
+                       ven_id=ven_id,
+                       resource_id=resource_id,
+                       measurement=measurement)
+    sampling_interval = min_sampling_interval
+    return callback, sampling_interval
+
+
+async def on_update_report(data, ven_id, resource_id, measurement):
+    """
+    Callback that receives report data from the VEN and handles it.
+    """
+    for time, value in data:
+        print(
+            f"Ven {ven_id} reported {measurement} = {value} at time {time} for resource {resource_id}"
+        )
+
+
+async def event_response_callback(ven_id, event_id, opt_type):
+    """
+    Callback that receives the response from a VEN to an Event.
+    """
+    print(f"VEN {ven_id} responded to Event {event_id} with: {opt_type}")
+
+
+def ven_lookup(ven_id):
+    return {
+        'ven_id': 'ven_id_123',
+        'ven_name': 'ven123',
+    }
+
+
+# Create the server object
+server = OpenADRServer(vtn_id='myvtn')
+
+# Add the handler for client (VEN) registrations
+server.add_handler('on_create_party_registration',
+                   on_create_party_registration)
+
+# Add the handler for report registrations from the VEN
+server.add_handler('on_register_report', on_register_report)
+
+# Add a prepared event for a VEN that will be picked up when it polls for new messages.
+server.add_event(
+    ven_id='ven_id_123',
+    signal_name='simple',
+    signal_type='level',
+    intervals=[{
+        'dtstart': datetime.now(timezone.utc) + timedelta(minutes=5),
+        'duration': timedelta(minutes=60),
+        'signal_payload': 100.0
+    }],
+    #  intervals=[{'dtstart': datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    #              'duration': timedelta(minutes=10),
+    #              'signal_payload': 1}],
+    callback=event_response_callback)
+
+# Run the server on the asyncio event loop
+loop = asyncio.get_event_loop()
+loop.create_task(server.run())
+loop.run_forever()

--- a/utils/vtn.py
+++ b/utils/vtn.py
@@ -1,3 +1,18 @@
+"""
+=======
+Toy VTN
+=======
+
+This VTN is to be used for testing the VolttronOpenADRVEN agent. This VTN will emit an Event to be polled by the VolttronOpenADRVEN agent, which in
+turn will process the Event and then publish the Event on the Volttron message bus.
+
+Events are informational or instructional messages from the server (VTN) which inform you of price changes, request load reduction, et cetera.
+The Event to be published has a single signal with an OpenADR name of "simple" and is of OpenADR type "level". This Event will have exactly one interval with a
+start time of now and end time of now + five minutes; the payload will be 100.0. When a VolttronOpenADRVEN agent is installed using the
+config_toy_ven.json agent configuration, the agent is expected to poll this Event from the toy VTN. Once the VEN has polled the Event, the VTN
+will stop sending out the Event.
+"""
+
 import asyncio
 from datetime import datetime, timezone, timedelta
 from openleadr import OpenADRServer, enable_default_logging
@@ -67,19 +82,18 @@ server.add_handler('on_create_party_registration',
 server.add_handler('on_register_report', on_register_report)
 
 # Add a prepared event for a VEN that will be picked up when it polls for new messages.
-server.add_event(
-    ven_id='ven_id_123',
-    signal_name='simple',
-    signal_type='level',
-    intervals=[{
-        'dtstart': datetime.now(timezone.utc) + timedelta(minutes=5),
-        'duration': timedelta(minutes=60),
-        'signal_payload': 100.0
-    }],
-    #  intervals=[{'dtstart': datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-    #              'duration': timedelta(minutes=10),
-    #              'signal_payload': 1}],
-    callback=event_response_callback)
+server.add_event(ven_id='ven_id_123',
+                 signal_name='simple',
+                 signal_type='level',
+                 intervals=[{
+                     'dtstart':
+                     datetime.now(timezone.utc) + timedelta(minutes=5),
+                     'duration':
+                     timedelta(minutes=60),
+                     'signal_payload':
+                     100.0
+                 }],
+                 callback=event_response_callback)
 
 # Run the server on the asyncio event loop
 loop = asyncio.get_event_loop()


### PR DESCRIPTION
* Add python script to create a local VTN so that users can test the VolttronOpenADRVEN agent without having to setup and potentially pay for a live VTN
* Add instructions in README on setting up VTN and testing the agent
* Update links in README
* Update pyproject.toml to use volttron-core's pinned version of gevent to ensure successful installation of agent via PyPi
* Update gitignore
* Comment out nice-to-have precommit hooks that are preventing a successful commit (will fix later)